### PR TITLE
Fix Vitest configuration and ensure tests run

### DIFF
--- a/apps/app/lib/example.test.ts
+++ b/apps/app/lib/example.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from "vitest";
+
+describe("Example Test", () => {
+  it("should pass", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -63,8 +63,10 @@ export default defineProject(({ mode }) => {
     plugins: [
       tsconfigPaths(),
       tanstackRouter({
-        routesDirectory: "./routes",
-        generatedRouteTree: "./lib/routeTree.gen.ts",
+        routesDirectory: fileURLToPath(new URL("./routes", import.meta.url)),
+        generatedRouteTree: fileURLToPath(
+          new URL("./lib/routeTree.gen.ts", import.meta.url),
+        ),
         routeFileIgnorePrefix: "-",
         quoteStyle: "single",
         semicolons: false,

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -2,21 +2,12 @@
 /* SPDX-License-Identifier: MIT */
 
 import { defineWorkspace } from "vitest/config";
-import { workspaces } from "./package.json";
 
 /**
  * Inline Vitest configuration for all workspaces.
  *
  * @see https://vitest.dev/guide/workspace
  */
-export default defineWorkspace(
-  workspaces
-    .filter((name) => !["scripts"].includes(name))
-    .map((name) => ({
-      extends: `./${name}/vite.config.ts`,
-      test: {
-        name,
-        root: `./${name}`,
-      },
-    })),
-);
+export default defineWorkspace([
+  "apps/app"
+]);


### PR DESCRIPTION
This PR fixes the broken test configuration in the repository.

1.  **Dependencies**: Installed missing `node_modules`.
2.  **Vitest Workspace**: Rewrote `vitest.workspace.ts` to explicitly include `apps/app`, replacing a broken dynamic configuration that was causing Vitest to fail on startup.
3.  **Vite Config**: Updated `apps/app/vite.config.ts` to use `import.meta.url` for resolving paths for `tanstackRouter`. This fixes an issue where running `vitest` from the root would fail to find the routes directory.
4.  **Sample Test**: Added a basic test case in `apps/app/lib/example.test.ts` to ensure the test runner is working correctly, as there were no existing tests in the codebase.

---
*PR created automatically by Jules for task [9276241340679548680](https://jules.google.com/task/9276241340679548680) started by @yufenggao-google*