### PR TITLE
fix(security): harden redirect URL validation against open redirects

### DIFF
--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,46 +1,45 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { isValidRedirectUrl } from "./auth-config";
 
-import { describe, it, expect, beforeAll } from 'vitest';
-import { isValidRedirectUrl } from './auth-config';
-
-describe('isValidRedirectUrl', () => {
+describe("isValidRedirectUrl", () => {
   const originalLocation = window.location;
 
   beforeAll(() => {
     // Mock window.location if not available (though happy-dom should provide it)
     if (!window.location) {
-        Object.defineProperty(global, 'window', {
-            value: {
-                location: {
-                    origin: 'http://localhost:5173'
-                }
-            },
-            writable: true
-        });
+      Object.defineProperty(global, "window", {
+        value: {
+          location: {
+            origin: "http://localhost:5173",
+          },
+        },
+        writable: true,
+      });
     }
   });
 
-  it('should allow simple relative paths', () => {
-    expect(isValidRedirectUrl('/dashboard')).toBe(true);
-    expect(isValidRedirectUrl('/settings/profile')).toBe(true);
+  it("should allow simple relative paths", () => {
+    expect(isValidRedirectUrl("/dashboard")).toBe(true);
+    expect(isValidRedirectUrl("/settings/profile")).toBe(true);
   });
 
-  it('should reject absolute URLs even if origin matches', () => {
-    expect(isValidRedirectUrl('http://localhost:5173/dashboard')).toBe(false);
+  it("should reject absolute URLs even if origin matches", () => {
+    expect(isValidRedirectUrl("http://localhost:5173/dashboard")).toBe(false);
   });
 
-  it('should reject external URLs', () => {
-    expect(isValidRedirectUrl('https://google.com')).toBe(false);
-    expect(isValidRedirectUrl('http://malicious.com')).toBe(false);
+  it("should reject external URLs", () => {
+    expect(isValidRedirectUrl("https://google.com")).toBe(false);
+    expect(isValidRedirectUrl("http://malicious.com")).toBe(false);
   });
 
-  it('should reject protocol-relative URLs', () => {
-    expect(isValidRedirectUrl('//google.com')).toBe(false);
+  it("should reject protocol-relative URLs", () => {
+    expect(isValidRedirectUrl("//google.com")).toBe(false);
   });
 
-  it('should reject URLs with backslashes (potential open redirect)', () => {
+  it("should reject URLs with backslashes (potential open redirect)", () => {
     // This is the one we expect to fail currently if the fix isn't applied
-    expect(isValidRedirectUrl('/\\google.com')).toBe(false);
-    expect(isValidRedirectUrl('\\google.com')).toBe(false);
-    expect(isValidRedirectUrl('/\\/google.com')).toBe(false);
+    expect(isValidRedirectUrl("/\\google.com")).toBe(false);
+    expect(isValidRedirectUrl("\\google.com")).toBe(false);
+    expect(isValidRedirectUrl("/\\/google.com")).toBe(false);
   });
 });

--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,0 +1,46 @@
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { isValidRedirectUrl } from './auth-config';
+
+describe('isValidRedirectUrl', () => {
+  const originalLocation = window.location;
+
+  beforeAll(() => {
+    // Mock window.location if not available (though happy-dom should provide it)
+    if (!window.location) {
+        Object.defineProperty(global, 'window', {
+            value: {
+                location: {
+                    origin: 'http://localhost:5173'
+                }
+            },
+            writable: true
+        });
+    }
+  });
+
+  it('should allow simple relative paths', () => {
+    expect(isValidRedirectUrl('/dashboard')).toBe(true);
+    expect(isValidRedirectUrl('/settings/profile')).toBe(true);
+  });
+
+  it('should reject absolute URLs even if origin matches', () => {
+    expect(isValidRedirectUrl('http://localhost:5173/dashboard')).toBe(false);
+  });
+
+  it('should reject external URLs', () => {
+    expect(isValidRedirectUrl('https://google.com')).toBe(false);
+    expect(isValidRedirectUrl('http://malicious.com')).toBe(false);
+  });
+
+  it('should reject protocol-relative URLs', () => {
+    expect(isValidRedirectUrl('//google.com')).toBe(false);
+  });
+
+  it('should reject URLs with backslashes (potential open redirect)', () => {
+    // This is the one we expect to fail currently if the fix isn't applied
+    expect(isValidRedirectUrl('/\\google.com')).toBe(false);
+    expect(isValidRedirectUrl('\\google.com')).toBe(false);
+    expect(isValidRedirectUrl('/\\/google.com')).toBe(false);
+  });
+});

--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -2,11 +2,9 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { isValidRedirectUrl } from "./auth-config";
 
 describe("isValidRedirectUrl", () => {
-  const originalLocation = window.location;
-
   beforeAll(() => {
     // Mock window.location if not available (though happy-dom should provide it)
-    if (!window.location) {
+    if (typeof window !== "undefined" && !window.location) {
       Object.defineProperty(global, "window", {
         value: {
           location: {

--- a/apps/app/lib/auth-config.ts
+++ b/apps/app/lib/auth-config.ts
@@ -98,7 +98,7 @@ export const authConfig = {
  */
 export function isValidRedirectUrl(url: string): boolean {
   // Only allow relative URLs starting with /
-  if (!url.startsWith("/") || url.startsWith("//")) {
+  if (!url.startsWith("/") || url.startsWith("//") || url.includes("\\")) {
     return false;
   }
 


### PR DESCRIPTION
This PR hardens the `isValidRedirectUrl` function in `apps/app/lib/auth-config.ts` to prevent open redirect vulnerabilities.

Changes:
- Explicitly rejects any URL containing a backslash (`\`).
- Adds a comprehensive test suite in `apps/app/lib/auth-config.test.ts` to verify:
    - Valid relative paths are allowed.
    - Absolute URLs are rejected.
    - Protocol-relative URLs (`//`) are rejected.
    - Backslash-containing URLs (`/\example.com`, `\example.com`) are rejected.

This ensures that malformed URLs cannot bypass origin checks, even if `new URL()` parsing is lenient in some environments.

---
*PR created automatically by Jules for task [10465844348732012520](https://jules.google.com/task/10465844348732012520) started by @yufenggao-google*