### PR TITLE
Fix test configuration and add auth-config tests

### DIFF
--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,0 +1,78 @@
+/* SPDX-FileCopyrightText: 2014-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+import { describe, expect, it } from "vitest";
+import {
+  getSafeRedirectUrl,
+  isValidRedirectUrl,
+  shouldRefreshSession,
+} from "./auth-config";
+
+describe("auth-config", () => {
+  describe("isValidRedirectUrl", () => {
+    it("should allow relative URLs", () => {
+      expect(isValidRedirectUrl("/dashboard")).toBe(true);
+      expect(isValidRedirectUrl("/settings/profile")).toBe(true);
+    });
+
+    it("should reject absolute URLs with different origin", () => {
+      expect(isValidRedirectUrl("https://example.com")).toBe(false);
+      expect(isValidRedirectUrl("http://evil.com/login")).toBe(false);
+    });
+
+    it("should reject protocol-relative URLs", () => {
+      expect(isValidRedirectUrl("//example.com")).toBe(false);
+    });
+
+    it("should reject URLs not starting with /", () => {
+      expect(isValidRedirectUrl("dashboard")).toBe(false);
+    });
+
+    it("should reject absolute URLs even if matching origin", () => {
+      const origin =
+        typeof window !== "undefined"
+          ? window.location.origin
+          : "http://localhost:5173";
+      // authConfig initializes allowedRedirectOrigins using window.location.origin.
+      expect(isValidRedirectUrl(`${origin}/dashboard`)).toBe(false);
+    });
+  });
+
+  describe("getSafeRedirectUrl", () => {
+    it("should return the URL if valid", () => {
+      expect(getSafeRedirectUrl("/dashboard")).toBe("/dashboard");
+    });
+
+    it("should return root if invalid", () => {
+      expect(getSafeRedirectUrl("https://example.com")).toBe("/");
+      expect(getSafeRedirectUrl(null)).toBe("/");
+      expect(getSafeRedirectUrl(undefined)).toBe("/");
+    });
+  });
+
+  describe("shouldRefreshSession", () => {
+    it("should return true if session is expiring soon", () => {
+      const now = Date.now();
+      // 5 minutes from now (threshold is 10 min)
+      const expiresAt = new Date(now + 5 * 60 * 1000);
+      expect(shouldRefreshSession(expiresAt)).toBe(true);
+    });
+
+    it("should return false if session is valid for a long time", () => {
+      const now = Date.now();
+      // 20 minutes from now
+      const expiresAt = new Date(now + 20 * 60 * 1000);
+      expect(shouldRefreshSession(expiresAt)).toBe(false);
+    });
+
+    it("should return false if session is already expired", () => {
+      const now = Date.now();
+      const expiresAt = new Date(now - 1000);
+      expect(shouldRefreshSession(expiresAt)).toBe(false);
+    });
+
+    it("should return false if expiresAt is missing", () => {
+      expect(shouldRefreshSession(undefined)).toBe(false);
+    });
+  });
+});

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -63,8 +63,10 @@ export default defineProject(({ mode }) => {
     plugins: [
       tsconfigPaths(),
       tanstackRouter({
-        routesDirectory: "./routes",
-        generatedRouteTree: "./lib/routeTree.gen.ts",
+        routesDirectory: fileURLToPath(new URL("./routes", import.meta.url)),
+        generatedRouteTree: fileURLToPath(
+          new URL("./lib/routeTree.gen.ts", import.meta.url),
+        ),
         routeFileIgnorePrefix: "-",
         quoteStyle: "single",
         semicolons: false,

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -10,13 +10,5 @@ import { workspaces } from "./package.json";
  * @see https://vitest.dev/guide/workspace
  */
 export default defineWorkspace(
-  workspaces
-    .filter((name) => !["scripts"].includes(name))
-    .map((name) => ({
-      extends: `./${name}/vite.config.ts`,
-      test: {
-        name,
-        root: `./${name}`,
-      },
-    })),
+  workspaces.filter((name) => !["scripts"].includes(name))
 );

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -10,5 +10,5 @@ import { workspaces } from "./package.json";
  * @see https://vitest.dev/guide/workspace
  */
 export default defineWorkspace(
-  workspaces.filter((name) => !["scripts"].includes(name))
+  workspaces.filter((name) => !["scripts"].includes(name)),
 );


### PR DESCRIPTION
Fixed vitest.workspace.ts to correctly handle globs. Updated apps/app/vite.config.ts to use absolute paths for TanStack Router plugin to support running tests from root. Added comprehensive tests for apps/app/lib/auth-config.ts.

---
*PR created automatically by Jules for task [3621232173512520916](https://jules.google.com/task/3621232173512520916) started by @yufenggao-google*