### PR TITLE
fix: vitest workspace config and add auth tests

### DIFF
--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,71 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidRedirectUrl,
+  getSafeRedirectUrl,
+  shouldRefreshSession,
+} from "./auth-config";
 
-import { describe, it, expect } from 'vitest';
-import { isValidRedirectUrl, getSafeRedirectUrl, shouldRefreshSession } from './auth-config';
-
-describe('auth-config', () => {
-  describe('isValidRedirectUrl', () => {
-    it('should accept relative URLs starting with /', () => {
-      expect(isValidRedirectUrl('/dashboard')).toBe(true);
-      expect(isValidRedirectUrl('/settings/profile')).toBe(true);
+describe("auth-config", () => {
+  describe("isValidRedirectUrl", () => {
+    it("should accept relative URLs starting with /", () => {
+      expect(isValidRedirectUrl("/dashboard")).toBe(true);
+      expect(isValidRedirectUrl("/settings/profile")).toBe(true);
     });
 
-    it('should reject URLs not starting with /', () => {
-      expect(isValidRedirectUrl('dashboard')).toBe(false);
-      expect(isValidRedirectUrl('https://example.com')).toBe(false);
+    it("should reject URLs not starting with /", () => {
+      expect(isValidRedirectUrl("dashboard")).toBe(false);
+      expect(isValidRedirectUrl("https://example.com")).toBe(false);
     });
 
-    it('should reject protocol-relative URLs', () => {
-      expect(isValidRedirectUrl('//example.com')).toBe(false);
-      expect(isValidRedirectUrl('//localhost')).toBe(false);
+    it("should reject protocol-relative URLs", () => {
+      expect(isValidRedirectUrl("//example.com")).toBe(false);
+      expect(isValidRedirectUrl("//localhost")).toBe(false);
     });
 
     // Security edge case: backslashes
-    it('should reject URLs with backslashes that could be normalized to //', () => {
-      expect(isValidRedirectUrl('/\\example.com')).toBe(false);
-      expect(isValidRedirectUrl('\\\\example.com')).toBe(false);
+    it("should reject URLs with backslashes that could be normalized to //", () => {
+      expect(isValidRedirectUrl("/\\example.com")).toBe(false);
+      expect(isValidRedirectUrl("\\\\example.com")).toBe(false);
     });
 
-    it('should reject absolute URLs even if matching the origin (strictly relative)', () => {
-       const origin = window.location.origin;
-       expect(isValidRedirectUrl(`${origin}/dashboard`)).toBe(false);
+    it("should reject absolute URLs even if matching the origin (strictly relative)", () => {
+      const origin = window.location.origin;
+      expect(isValidRedirectUrl(`${origin}/dashboard`)).toBe(false);
     });
 
-    it('should reject absolute URLs with different origin', () => {
-       expect(isValidRedirectUrl('https://evil.com/dashboard')).toBe(false);
-    });
-  });
-
-  describe('getSafeRedirectUrl', () => {
-    it('should return valid URLs as is', () => {
-      expect(getSafeRedirectUrl('/dashboard')).toBe('/dashboard');
-    });
-
-    it('should return / for invalid URLs', () => {
-      expect(getSafeRedirectUrl('https://evil.com')).toBe('/');
-      expect(getSafeRedirectUrl(null)).toBe('/');
-      expect(getSafeRedirectUrl(undefined)).toBe('/');
+    it("should reject absolute URLs with different origin", () => {
+      expect(isValidRedirectUrl("https://evil.com/dashboard")).toBe(false);
     });
   });
 
-  describe('shouldRefreshSession', () => {
-     it('should return false if no expiry date', () => {
-         expect(shouldRefreshSession(undefined)).toBe(false);
-     });
+  describe("getSafeRedirectUrl", () => {
+    it("should return valid URLs as is", () => {
+      expect(getSafeRedirectUrl("/dashboard")).toBe("/dashboard");
+    });
 
-     it('should return true if expiring soon', () => {
-         // Default threshold is 10 minutes
-         const soon = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes from now
-         expect(shouldRefreshSession(soon)).toBe(true);
-     });
+    it("should return / for invalid URLs", () => {
+      expect(getSafeRedirectUrl("https://evil.com")).toBe("/");
+      expect(getSafeRedirectUrl(null)).toBe("/");
+      expect(getSafeRedirectUrl(undefined)).toBe("/");
+    });
+  });
 
-     it('should return false if not expiring soon', () => {
-         const later = new Date(Date.now() + 20 * 60 * 1000); // 20 minutes from now
-         expect(shouldRefreshSession(later)).toBe(false);
-     });
+  describe("shouldRefreshSession", () => {
+    it("should return false if no expiry date", () => {
+      expect(shouldRefreshSession(undefined)).toBe(false);
+    });
 
-     it('should return false if already expired', () => {
-         const past = new Date(Date.now() - 1000);
-         expect(shouldRefreshSession(past)).toBe(false);
-     });
+    it("should return true if expiring soon", () => {
+      // Default threshold is 10 minutes
+      const soon = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes from now
+      expect(shouldRefreshSession(soon)).toBe(true);
+    });
+
+    it("should return false if not expiring soon", () => {
+      const later = new Date(Date.now() + 20 * 60 * 1000); // 20 minutes from now
+      expect(shouldRefreshSession(later)).toBe(false);
+    });
+
+    it("should return false if already expired", () => {
+      const past = new Date(Date.now() - 1000);
+      expect(shouldRefreshSession(past)).toBe(false);
+    });
   });
 });

--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,0 +1,71 @@
+
+import { describe, it, expect } from 'vitest';
+import { isValidRedirectUrl, getSafeRedirectUrl, shouldRefreshSession } from './auth-config';
+
+describe('auth-config', () => {
+  describe('isValidRedirectUrl', () => {
+    it('should accept relative URLs starting with /', () => {
+      expect(isValidRedirectUrl('/dashboard')).toBe(true);
+      expect(isValidRedirectUrl('/settings/profile')).toBe(true);
+    });
+
+    it('should reject URLs not starting with /', () => {
+      expect(isValidRedirectUrl('dashboard')).toBe(false);
+      expect(isValidRedirectUrl('https://example.com')).toBe(false);
+    });
+
+    it('should reject protocol-relative URLs', () => {
+      expect(isValidRedirectUrl('//example.com')).toBe(false);
+      expect(isValidRedirectUrl('//localhost')).toBe(false);
+    });
+
+    // Security edge case: backslashes
+    it('should reject URLs with backslashes that could be normalized to //', () => {
+      expect(isValidRedirectUrl('/\\example.com')).toBe(false);
+      expect(isValidRedirectUrl('\\\\example.com')).toBe(false);
+    });
+
+    it('should reject absolute URLs even if matching the origin (strictly relative)', () => {
+       const origin = window.location.origin;
+       expect(isValidRedirectUrl(`${origin}/dashboard`)).toBe(false);
+    });
+
+    it('should reject absolute URLs with different origin', () => {
+       expect(isValidRedirectUrl('https://evil.com/dashboard')).toBe(false);
+    });
+  });
+
+  describe('getSafeRedirectUrl', () => {
+    it('should return valid URLs as is', () => {
+      expect(getSafeRedirectUrl('/dashboard')).toBe('/dashboard');
+    });
+
+    it('should return / for invalid URLs', () => {
+      expect(getSafeRedirectUrl('https://evil.com')).toBe('/');
+      expect(getSafeRedirectUrl(null)).toBe('/');
+      expect(getSafeRedirectUrl(undefined)).toBe('/');
+    });
+  });
+
+  describe('shouldRefreshSession', () => {
+     it('should return false if no expiry date', () => {
+         expect(shouldRefreshSession(undefined)).toBe(false);
+     });
+
+     it('should return true if expiring soon', () => {
+         // Default threshold is 10 minutes
+         const soon = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes from now
+         expect(shouldRefreshSession(soon)).toBe(true);
+     });
+
+     it('should return false if not expiring soon', () => {
+         const later = new Date(Date.now() + 20 * 60 * 1000); // 20 minutes from now
+         expect(shouldRefreshSession(later)).toBe(false);
+     });
+
+     it('should return false if already expired', () => {
+         const past = new Date(Date.now() - 1000);
+         expect(shouldRefreshSession(past)).toBe(false);
+     });
+  });
+});

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -63,8 +63,10 @@ export default defineProject(({ mode }) => {
     plugins: [
       tsconfigPaths(),
       tanstackRouter({
-        routesDirectory: "./routes",
-        generatedRouteTree: "./lib/routeTree.gen.ts",
+        routesDirectory: fileURLToPath(new URL("./routes", import.meta.url)),
+        generatedRouteTree: fileURLToPath(
+          new URL("./lib/routeTree.gen.ts", import.meta.url),
+        ),
         routeFileIgnorePrefix: "-",
         quoteStyle: "single",
         semicolons: false,

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -10,13 +10,5 @@ import { workspaces } from "./package.json";
  * @see https://vitest.dev/guide/workspace
  */
 export default defineWorkspace(
-  workspaces
-    .filter((name) => !["scripts"].includes(name))
-    .map((name) => ({
-      extends: `./${name}/vite.config.ts`,
-      test: {
-        name,
-        root: `./${name}`,
-      },
-    })),
+  workspaces.filter((name) => !["scripts"].includes(name)),
 );


### PR DESCRIPTION
This PR fixes the test infrastructure by updating the Vitest workspace configuration and the Vite configuration for the app workspace. It also introduces a new test suite for the authentication configuration logic in `apps/app/lib/auth-config.ts`, ensuring robust security checks for redirect URLs and session management.

---
*PR created automatically by Jules for task [982570139216680161](https://jules.google.com/task/982570139216680161) started by @yufenggao-google*