### PR TITLE
fix(auth): prevent open redirects via backslashes

### DIFF
--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import {
-  isValidRedirectUrl,
-  getSafeRedirectUrl,
-  authConfig,
-} from "./auth-config";
+import { isValidRedirectUrl, getSafeRedirectUrl } from "./auth-config";
 
 describe("auth-config security", () => {
   const originalWindow = global.window;
@@ -14,6 +10,7 @@ describe("auth-config security", () => {
       location: {
         origin: "http://localhost:5173",
       },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
   });
 
@@ -48,6 +45,7 @@ describe("auth-config security", () => {
 
     it("handles SSR (no window)", () => {
       const tempWindow = global.window;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (global as any).window;
 
       // When window is undefined, window.location.origin throws,

--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  isValidRedirectUrl,
+  getSafeRedirectUrl,
+  authConfig,
+} from "./auth-config";
+
+describe("auth-config security", () => {
+  const originalWindow = global.window;
+
+  beforeEach(() => {
+    // Mock window.location for client-side tests
+    global.window = {
+      location: {
+        origin: "http://localhost:5173",
+      },
+    } as any;
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
+  describe("isValidRedirectUrl", () => {
+    it("accepts valid relative paths", () => {
+      expect(isValidRedirectUrl("/dashboard")).toBe(true);
+      expect(isValidRedirectUrl("/settings/profile")).toBe(true);
+      expect(isValidRedirectUrl("/?foo=bar")).toBe(true);
+    });
+
+    it("rejects absolute URLs", () => {
+      expect(isValidRedirectUrl("https://example.com")).toBe(false);
+      expect(isValidRedirectUrl("http://example.com")).toBe(false);
+      expect(isValidRedirectUrl("ftp://example.com")).toBe(false);
+    });
+
+    it("rejects protocol-relative URLs", () => {
+      expect(isValidRedirectUrl("//example.com")).toBe(false);
+      expect(isValidRedirectUrl("//localhost:5173")).toBe(false);
+    });
+
+    it("rejects URLs with backslashes to prevent open redirects", () => {
+      // These are the cases we expect to fail but currently might pass if the check is missing
+      expect(isValidRedirectUrl("/\\example.com")).toBe(false);
+      expect(isValidRedirectUrl("\\example.com")).toBe(false);
+      expect(isValidRedirectUrl("/foo\\bar")).toBe(false);
+    });
+
+    it("handles SSR (no window)", () => {
+      const tempWindow = global.window;
+      delete (global as any).window;
+
+      // When window is undefined, window.location.origin throws,
+      // so it goes to catch block and returns false.
+      expect(isValidRedirectUrl("/dashboard")).toBe(false);
+
+      global.window = tempWindow;
+    });
+  });
+
+  describe("getSafeRedirectUrl", () => {
+    it("returns default for invalid URLs", () => {
+      expect(getSafeRedirectUrl("https://evil.com")).toBe("/");
+      expect(getSafeRedirectUrl("//evil.com")).toBe("/");
+      expect(getSafeRedirectUrl(null)).toBe("/");
+      expect(getSafeRedirectUrl(undefined)).toBe("/");
+    });
+
+    it("returns the URL for valid inputs", () => {
+      expect(getSafeRedirectUrl("/dashboard")).toBe("/dashboard");
+    });
+  });
+});

--- a/apps/app/lib/auth-config.ts
+++ b/apps/app/lib/auth-config.ts
@@ -98,7 +98,8 @@ export const authConfig = {
  */
 export function isValidRedirectUrl(url: string): boolean {
   // Only allow relative URLs starting with /
-  if (!url.startsWith("/") || url.startsWith("//")) {
+  // Reject protocol-relative URLs (//) and backslashes (\) to prevent open redirects
+  if (!url.startsWith("/") || url.startsWith("//") || url.includes("\\")) {
     return false;
   }
 


### PR DESCRIPTION
This PR fixes a potential open redirect vulnerability in `isValidRedirectUrl` by explicitly rejecting URLs containing backslashes. 

Changes:
- Modified `apps/app/lib/auth-config.ts` to return `false` if the URL contains `\`.
- Created `apps/app/lib/auth-config.test.ts` (if it didn't exist properly or was empty) to test valid and invalid redirect URLs, including backslash cases.

This addresses the security requirement to prevent attackers from using backslashes to bypass protocol-relative URL checks.

---
*PR created automatically by Jules for task [982996851770414622](https://jules.google.com/task/982996851770414622) started by @yufenggao-google*