### PR TITLE
fix(test): configure vitest workspace and path resolution

### DIFF
--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidRedirectUrl,
+  getSafeRedirectUrl,
+  shouldRefreshSession,
+} from "./auth-config";
+
+describe("auth-config", () => {
+  describe("isValidRedirectUrl", () => {
+    it("should accept valid relative URLs", () => {
+      expect(isValidRedirectUrl("/dashboard")).toBe(true);
+      expect(isValidRedirectUrl("/settings/profile")).toBe(true);
+    });
+
+    it("should reject absolute URLs", () => {
+      expect(isValidRedirectUrl("https://example.com")).toBe(false);
+      expect(isValidRedirectUrl("http://google.com")).toBe(false);
+    });
+
+    it("should reject protocol-relative URLs", () => {
+      expect(isValidRedirectUrl("//example.com")).toBe(false);
+    });
+
+    it("should reject URLs without leading slash", () => {
+      expect(isValidRedirectUrl("dashboard")).toBe(false);
+    });
+  });
+
+  describe("getSafeRedirectUrl", () => {
+    it("should return the URL if valid", () => {
+      expect(getSafeRedirectUrl("/dashboard")).toBe("/dashboard");
+    });
+
+    it("should return / if invalid", () => {
+      expect(getSafeRedirectUrl("https://example.com")).toBe("/");
+      expect(getSafeRedirectUrl("//example.com")).toBe("/");
+      expect(getSafeRedirectUrl("invalid")).toBe("/");
+    });
+
+    it("should return / if null or undefined", () => {
+      expect(getSafeRedirectUrl(null)).toBe("/");
+      expect(getSafeRedirectUrl(undefined)).toBe("/");
+    });
+  });
+
+  describe("shouldRefreshSession", () => {
+    it("should return true if session is expiring soon", () => {
+      const now = Date.now();
+      // Expiring in 5 minutes (threshold is 10 minutes)
+      const expiringSoon = new Date(now + 5 * 60 * 1000);
+      expect(shouldRefreshSession(expiringSoon)).toBe(true);
+    });
+
+    it("should return false if session is not expiring soon", () => {
+      const now = Date.now();
+      // Expiring in 20 minutes
+      const notExpiringSoon = new Date(now + 20 * 60 * 1000);
+      expect(shouldRefreshSession(notExpiringSoon)).toBe(false);
+    });
+
+    it("should return false if session is already expired", () => {
+      const now = Date.now();
+      const expired = new Date(now - 1000);
+      expect(shouldRefreshSession(expired)).toBe(false);
+    });
+
+    it("should return false if expiresAt is undefined", () => {
+      expect(shouldRefreshSession(undefined)).toBe(false);
+    });
+  });
+});

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -63,8 +63,10 @@ export default defineProject(({ mode }) => {
     plugins: [
       tsconfigPaths(),
       tanstackRouter({
-        routesDirectory: "./routes",
-        generatedRouteTree: "./lib/routeTree.gen.ts",
+        routesDirectory: fileURLToPath(new URL("./routes", import.meta.url)),
+        generatedRouteTree: fileURLToPath(
+          new URL("./lib/routeTree.gen.ts", import.meta.url),
+        ),
         routeFileIgnorePrefix: "-",
         quoteStyle: "single",
         semicolons: false,

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -8,8 +8,4 @@ import { defineWorkspace } from "vitest/config";
  *
  * @see https://vitest.dev/guide/workspace
  */
-export default defineWorkspace([
-  "apps/*",
-  "packages/*",
-  "db"
-]);
+export default defineWorkspace(["apps/*", "packages/*", "db"]);

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -2,21 +2,14 @@
 /* SPDX-License-Identifier: MIT */
 
 import { defineWorkspace } from "vitest/config";
-import { workspaces } from "./package.json";
 
 /**
  * Inline Vitest configuration for all workspaces.
  *
  * @see https://vitest.dev/guide/workspace
  */
-export default defineWorkspace(
-  workspaces
-    .filter((name) => !["scripts"].includes(name))
-    .map((name) => ({
-      extends: `./${name}/vite.config.ts`,
-      test: {
-        name,
-        root: `./${name}`,
-      },
-    })),
-);
+export default defineWorkspace([
+  "apps/*",
+  "packages/*",
+  "db"
+]);


### PR DESCRIPTION
This PR fixes the Vitest configuration to correctly identify workspaces and resolve paths when running tests from the project root. It also adds initial unit tests for the authentication configuration logic.

1. **Workspace Configuration**: Replaced dynamic workspace mapping in `vitest.workspace.ts` with static glob patterns `["apps/*", "packages/*", "db"]`. This prevents errors when scanning directories without `vite.config.ts` (like `db` or `apps/api`) and resolves issues with wildcard expansion.

2. **Path Resolution**: Updated `apps/app/vite.config.ts` to use `fileURLToPath(new URL(..., import.meta.url))` for `tanstackRouter` configuration. This ensures that the paths to `routes` and `generatedRouteTree` are resolved correctly relative to the config file, regardless of the current working directory (e.g., when running `vitest` from the root).

3. **New Tests**: Added `apps/app/lib/auth-config.test.ts` with test cases for:
    - `isValidRedirectUrl`: Verifies security checks for relative/absolute URLs.
    - `getSafeRedirectUrl`: Verifies fallback behavior.
    - `shouldRefreshSession`: Verifies session expiration logic.

This ensures that `bun run test` now executes successfully and runs the added tests.

---
*PR created automatically by Jules for task [1986138801217689007](https://jules.google.com/task/1986138801217689007) started by @yufenggao-google*