### PR TITLE
fix(auth): reject backslashes in redirect URLs

### DIFF
--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,0 +1,28 @@
+
+import { describe, expect, test } from "vitest";
+import { isValidRedirectUrl } from "./auth-config";
+
+describe("isValidRedirectUrl", () => {
+  // Uses default happy-dom origin (http://localhost:3000)
+
+  test("allows valid relative paths", () => {
+    expect(isValidRedirectUrl("/dashboard")).toBe(true);
+    expect(isValidRedirectUrl("/settings/profile")).toBe(true);
+    expect(isValidRedirectUrl("/")).toBe(true);
+  });
+
+  test("rejects absolute URLs", () => {
+    expect(isValidRedirectUrl("https://example.com")).toBe(false);
+    expect(isValidRedirectUrl("http://evil.com")).toBe(false);
+  });
+
+  test("rejects protocol-relative URLs", () => {
+    expect(isValidRedirectUrl("//evil.com")).toBe(false);
+  });
+
+  test("rejects URLs with backslashes", () => {
+    expect(isValidRedirectUrl("/\\evil.com")).toBe(false);
+    expect(isValidRedirectUrl("\\evil.com")).toBe(false);
+    expect(isValidRedirectUrl("/foo\\bar")).toBe(false);
+  });
+});

--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,4 +1,3 @@
-
 import { describe, expect, test } from "vitest";
 import { isValidRedirectUrl } from "./auth-config";
 

--- a/apps/app/lib/auth-config.ts
+++ b/apps/app/lib/auth-config.ts
@@ -98,7 +98,7 @@ export const authConfig = {
  */
 export function isValidRedirectUrl(url: string): boolean {
   // Only allow relative URLs starting with /
-  if (!url.startsWith("/") || url.startsWith("//")) {
+  if (!url.startsWith("/") || url.startsWith("//") || url.includes("\\")) {
     return false;
   }
 


### PR DESCRIPTION
This change hardens the `isValidRedirectUrl` function in `apps/app/lib/auth-config.ts` by explicitly rejecting URLs containing backslashes. This prevents potential open redirect vulnerabilities where backslashes could be treated as directory separators or normalized to forward slashes by browsers or URL parsers, allowing attackers to bypass the relative path check.

I also added a new test file `apps/app/lib/auth-config.test.ts` (which was missing) to verify the fix and ensure that:
1. Valid relative paths (`/dashboard`, `/`) are still allowed.
2. Absolute URLs (`https://example.com`) are rejected.
3. Protocol-relative URLs (`//evil.com`) are rejected.
4. URLs with backslashes (`/\evil.com`, `\evil.com`) are rejected.

The tests run in the `happy-dom` environment as configured for the app workspace.

---
*PR created automatically by Jules for task [16002255914925669191](https://jules.google.com/task/16002255914925669191) started by @yufenggao-google*