### PR TITLE
fix(app): harden redirect validation against open redirects and SSR crashes

### DIFF
--- a/apps/app/lib/auth-config.ssr.test.ts
+++ b/apps/app/lib/auth-config.ssr.test.ts
@@ -1,0 +1,10 @@
+// @vitest-environment node
+import { describe, expect, test } from "vitest";
+import { isValidRedirectUrl } from "./auth-config";
+
+describe("isValidRedirectUrl (SSR)", () => {
+  test("handles missing window gracefully", () => {
+    // This should not throw
+    expect(isValidRedirectUrl("/dashboard")).toBe(true);
+  });
+});

--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import { isValidRedirectUrl, shouldRefreshSession } from "./auth-config";
+
+describe("isValidRedirectUrl", () => {
+  test("allows valid relative URLs", () => {
+    expect(isValidRedirectUrl("/")).toBe(true);
+    expect(isValidRedirectUrl("/dashboard")).toBe(true);
+    expect(isValidRedirectUrl("/settings/profile")).toBe(true);
+    expect(isValidRedirectUrl("/foo?bar=baz")).toBe(true);
+  });
+
+  test("rejects absolute URLs", () => {
+    expect(isValidRedirectUrl("https://example.com")).toBe(false);
+    expect(isValidRedirectUrl("http://example.com")).toBe(false);
+    expect(isValidRedirectUrl("ftp://example.com")).toBe(false);
+  });
+
+  test("rejects protocol-relative URLs", () => {
+    expect(isValidRedirectUrl("//example.com")).toBe(false);
+    expect(isValidRedirectUrl("//localhost:3000")).toBe(false);
+  });
+
+  test("rejects URLs with backslashes (open redirect bypass)", () => {
+    expect(isValidRedirectUrl("/\\example.com")).toBe(false);
+    expect(isValidRedirectUrl("\\example.com")).toBe(false);
+    expect(isValidRedirectUrl("/foo\\bar")).toBe(false);
+  });
+
+  test("rejects whitespace and control characters", () => {
+    expect(isValidRedirectUrl("/  /example.com")).toBe(true); // Should be treated as path
+    expect(isValidRedirectUrl(" /example.com")).toBe(false); // Does not start with /
+  });
+});
+
+describe("shouldRefreshSession", () => {
+  test("returns false if no expiry provided", () => {
+    expect(shouldRefreshSession(undefined)).toBe(false);
+  });
+
+  test("returns false if expired", () => {
+    const past = new Date(Date.now() - 1000);
+    expect(shouldRefreshSession(past)).toBe(false);
+  });
+
+  test("returns false if expiry is far in future", () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+    expect(shouldRefreshSession(future)).toBe(false);
+  });
+
+  test("returns true if expiry is within threshold", () => {
+    // Threshold is 10 minutes (10 * 60 * 1000 = 600,000 ms)
+    const soon = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes
+    expect(shouldRefreshSession(soon)).toBe(true);
+  });
+});

--- a/apps/app/lib/auth-config.ts
+++ b/apps/app/lib/auth-config.ts
@@ -98,12 +98,17 @@ export const authConfig = {
  */
 export function isValidRedirectUrl(url: string): boolean {
   // Only allow relative URLs starting with /
-  if (!url.startsWith("/") || url.startsWith("//")) {
+  // Reject protocol-relative URLs (//) and backslashes (\) to prevent open redirects
+  if (!url.startsWith("/") || url.startsWith("//") || url.includes("\\")) {
     return false;
   }
 
   try {
-    const parsed = new URL(url, window.location.origin);
+    const base =
+      typeof window !== "undefined"
+        ? window.location.origin
+        : "http://localhost:5173";
+    const parsed = new URL(url, base);
     // Check if origin matches allowed origins
     return authConfig.security.allowedRedirectOrigins.includes(parsed.origin);
   } catch {


### PR DESCRIPTION
Prevents open redirect vulnerabilities by explicitly rejecting backslashes in `isValidRedirectUrl`.
Additionally improves SSR compatibility by handling missing `window` object gracefully.
Added comprehensive unit tests covering relative paths, absolute URLs, protocol-relative URLs, backslashes, and SSR environment.

---
*PR created automatically by Jules for task [6954807413482137527](https://jules.google.com/task/6954807413482137527) started by @yufenggao-google*