### PR TITLE
Fix Open Redirect vulnerability by rejecting backslashes in URLs

### DIFF
--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 import { getSafeRedirectUrl, isValidRedirectUrl } from "./auth-config";
 
+// Unit tests for auth configuration helpers
 describe("isValidRedirectUrl", () => {
   it("should return true for valid relative URLs", () => {
     expect(isValidRedirectUrl("/")).toBe(true);

--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,0 +1,55 @@
+/* SPDX-FileCopyrightText: 2014-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+import { describe, expect, it } from "vitest";
+import { getSafeRedirectUrl, isValidRedirectUrl } from "./auth-config";
+
+describe("isValidRedirectUrl", () => {
+  it("should return true for valid relative URLs", () => {
+    expect(isValidRedirectUrl("/")).toBe(true);
+    expect(isValidRedirectUrl("/dashboard")).toBe(true);
+    expect(isValidRedirectUrl("/settings/profile")).toBe(true);
+    expect(isValidRedirectUrl("/users/123")).toBe(true);
+  });
+
+  it("should return false for absolute URLs", () => {
+    expect(isValidRedirectUrl("https://example.com")).toBe(false);
+    expect(isValidRedirectUrl("http://google.com")).toBe(false);
+    expect(isValidRedirectUrl("ftp://example.com")).toBe(false);
+  });
+
+  it("should return false for protocol-relative URLs", () => {
+    expect(isValidRedirectUrl("//google.com")).toBe(false);
+    expect(isValidRedirectUrl("//localhost")).toBe(false);
+  });
+
+  it("should return false for URLs with backslashes", () => {
+    expect(isValidRedirectUrl("/\\google.com")).toBe(false);
+    expect(isValidRedirectUrl("\\\\google.com")).toBe(false);
+    expect(isValidRedirectUrl("/foo\\bar")).toBe(false);
+  });
+
+  it("should return false for malformed URLs", () => {
+    expect(isValidRedirectUrl("javascript:alert(1)")).toBe(false);
+    expect(isValidRedirectUrl("data:text/html,Hello")).toBe(false);
+  });
+});
+
+describe("getSafeRedirectUrl", () => {
+  it("should return the URL if it is valid", () => {
+    expect(getSafeRedirectUrl("/dashboard")).toBe("/dashboard");
+  });
+
+  it("should return / if the URL is invalid", () => {
+    expect(getSafeRedirectUrl("https://google.com")).toBe("/");
+    expect(getSafeRedirectUrl("//google.com")).toBe("/");
+    expect(getSafeRedirectUrl("/\\google.com")).toBe("/");
+  });
+
+  it("should return / if the URL is not a string", () => {
+    expect(getSafeRedirectUrl(null)).toBe("/");
+    expect(getSafeRedirectUrl(undefined)).toBe("/");
+    expect(getSafeRedirectUrl(123)).toBe("/");
+    expect(getSafeRedirectUrl({})).toBe("/");
+  });
+});

--- a/apps/app/lib/auth-config.ts
+++ b/apps/app/lib/auth-config.ts
@@ -91,14 +91,15 @@ export const authConfig = {
  * Validates redirect URLs to prevent open redirect attacks
  *
  * SECURITY: Rejects protocol-relative URLs (//example.com) and absolute URLs
- * to external domains. Only relative paths within allowed origins pass.
+ * to external domains. Also rejects URLs containing backslashes to prevent
+ * browser-specific parsing issues. Only relative paths within allowed origins pass.
  *
  * @param url - URL to validate
  * @returns true if URL is safe to redirect to
  */
 export function isValidRedirectUrl(url: string): boolean {
   // Only allow relative URLs starting with /
-  if (!url.startsWith("/") || url.startsWith("//")) {
+  if (!url.startsWith("/") || url.startsWith("//") || url.includes("\\")) {
     return false;
   }
 


### PR DESCRIPTION
Modified isValidRedirectUrl in apps/app/lib/auth-config.ts to strictly reject URLs containing backslashes. Added comprehensive tests in apps/app/lib/auth-config.test.ts covering valid, invalid, protocol-relative, and backslash-containing URLs.

---
*PR created automatically by Jules for task [14414265922903768337](https://jules.google.com/task/14414265922903768337) started by @yufenggao-google*