### PR TITLE
fix(security): reject backslashes in redirect URLs to prevent open redirects

### DIFF
--- a/apps/app/lib/auth-config.test.ts
+++ b/apps/app/lib/auth-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { isValidRedirectUrl } from "./auth-config";
+
+describe("isValidRedirectUrl", () => {
+  it("allows valid relative paths", () => {
+    expect(isValidRedirectUrl("/dashboard")).toBe(true);
+    expect(isValidRedirectUrl("/settings/profile")).toBe(true);
+  });
+
+  it("rejects absolute URLs with different origin", () => {
+    expect(isValidRedirectUrl("https://evil.com")).toBe(false);
+    expect(isValidRedirectUrl("http://evil.com")).toBe(false);
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(isValidRedirectUrl("//evil.com")).toBe(false);
+  });
+
+  it("should reject backslashes to prevent open redirects", () => {
+    // This is the security fix we need to implement
+    expect(isValidRedirectUrl("/\\evil.com")).toBe(false);
+    expect(isValidRedirectUrl("\\\\evil.com")).toBe(false);
+    // This case currently passes (returns true) in HappyDOM but should be rejected for security
+    expect(isValidRedirectUrl("/foo\\bar")).toBe(false);
+  });
+});

--- a/apps/app/lib/auth-config.ts
+++ b/apps/app/lib/auth-config.ts
@@ -98,7 +98,7 @@ export const authConfig = {
  */
 export function isValidRedirectUrl(url: string): boolean {
   // Only allow relative URLs starting with /
-  if (!url.startsWith("/") || url.startsWith("//")) {
+  if (!url.startsWith("/") || url.startsWith("//") || url.includes("\\")) {
     return false;
   }
 


### PR DESCRIPTION
This PR hardens the `isValidRedirectUrl` function in `apps/app/lib/auth-config.ts` to explicitly reject any URL containing a backslash (`\`). 

This change addresses a potential Open Redirect vulnerability where backslashes could be used to bypass the relative path check (e.g., `/\evil.com`) in some environments or browsers that might normalize them to forward slashes or treat them as valid path separators.

It also introduces a new test file `apps/app/lib/auth-config.test.ts` to verify the security fix and ensure no regressions for valid URLs.

---
*PR created automatically by Jules for task [2955277993018919766](https://jules.google.com/task/2955277993018919766) started by @yufenggao-google*